### PR TITLE
ci: add NuGet publish workflow and repository metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  packages: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: nuget
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore
+
+      - name: Test
+        run: dotnet test --no-build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Pack
+        run: dotnet pack src/Crap4DotNet.Cli -o ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -31,12 +33,8 @@ jobs:
       - name: Test
         run: dotnet test --no-build
 
-      - name: Extract version from tag
-        id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - name: Pack
-        run: dotnet pack src/Crap4DotNet.Cli -o ./nupkg /p:Version=${{ steps.version.outputs.VERSION }}
+        run: dotnet pack src/Crap4DotNet.Cli -o ./nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,9 @@
     <!-- CLI framework -->
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 
+    <!-- Versioning -->
+    <PackageVersion Include="MinVer" Version="7.0.0" />
+
     <!-- JSON serialization -->
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # crap4dotnet
 
+[![NuGet](https://img.shields.io/nuget/v/Crap4DotNet)](https://www.nuget.org/packages/Crap4DotNet)
+[![CI](https://github.com/7Factor/crap4dotnet/actions/workflows/ci.yml/badge.svg)](https://github.com/7Factor/crap4dotnet/actions/workflows/ci.yml)
+
 A .NET global tool that computes **CRAP (Change Risk Anti-Patterns)** scores for your C# code. CRAP combines cyclomatic complexity with code coverage to identify methods that are both complex and poorly tested — the riskiest code in your project.
 
 Designed for **AI agent consumption**: JSON to stdout, structured errors to stderr, meaningful exit codes.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,8 @@ Methods with a CRAP score above the threshold (default: 30) are **CRAPpy** — t
 
 ## Install
 
-Not yet published to NuGet. Install from source:
-
 ```bash
-git clone <repo-url> && cd crap4dotnet
-dotnet pack src/Crap4DotNet.Cli -o ./nupkg
-dotnet tool install -g Crap4DotNet --add-source ./nupkg
+dotnet tool install -g Crap4DotNet
 ```
 
 Requires .NET 8.0 or later.
@@ -194,7 +190,7 @@ Complexity analysis is purely syntactic (no semantic model needed), so the tool 
 ## Building from Source
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/7Factor/crap4dotnet.git
 cd crap4dotnet
 dotnet build
 dotnet test

--- a/src/Crap4DotNet.Cli/Crap4DotNet.Cli.csproj
+++ b/src/Crap4DotNet.Cli/Crap4DotNet.Cli.csproj
@@ -10,6 +10,9 @@
     <Description>CLI tool for computing CRAP (Change Risk Anti-Patterns) scores on .NET projects. Combines cyclomatic complexity with code coverage to identify risky, under-tested methods.</Description>
     <PackageTags>crap;metrics;code-quality;complexity;coverage;dotnet-tool</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/7Factor/crap4dotnet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageProjectUrl>https://github.com/7Factor/crap4dotnet</PackageProjectUrl>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-crap</ToolCommandName>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Crap4DotNet.Cli/Crap4DotNet.Cli.csproj
+++ b/src/Crap4DotNet.Cli/Crap4DotNet.Cli.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Crap4DotNet.Cli</RootNamespace>
     <AssemblyName>dotnet-crap</AssemblyName>
     <PackageId>Crap4DotNet</PackageId>
-    <Version>0.1.0</Version>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
     <Authors>7f</Authors>
     <Description>CLI tool for computing CRAP (Change Risk Anti-Patterns) scores on .NET projects. Combines cyclomatic complexity with code coverage to identify risky, under-tested methods.</Description>
     <PackageTags>crap;metrics;code-quality;complexity;coverage;dotnet-tool</PackageTags>
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MinVer" PrivateAssets="All" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/src/Crap4DotNet.Cli/README.md
+++ b/src/Crap4DotNet.Cli/README.md
@@ -13,20 +13,20 @@ dotnet tool install -g Crap4DotNet
 ## Usage
 
 ```bash
-# Analyze a project (auto-discovers coverage from TestResults)
-dotnet crap analyze ./src/MyProject
+# Run tests and analyze in one step
+dotnet-crap analyze ./MyApp.sln --run-tests
 
 # Analyze with explicit coverage file
-dotnet crap analyze ./src/MyProject --coverage ./TestResults/coverage.cobertura.xml
+dotnet-crap analyze ./src/MyProject --coverage ./TestResults/coverage.cobertura.xml
 
 # Write report to file
-dotnet crap analyze ./src/MyProject --output report.json
+dotnet-crap analyze ./src/MyProject --coverage ./coverage.xml --output report.json
 
 # Custom threshold (default: 30)
-dotnet crap analyze ./src/MyProject --threshold 15
+dotnet-crap analyze ./src/MyProject --coverage ./coverage.xml --threshold 15
 
 # Compare two reports
-dotnet crap diff before.json after.json
+dotnet-crap diff before.json after.json
 ```
 
 ## Exit Codes
@@ -48,4 +48,4 @@ A method with complexity 20 and 10% coverage has a CRAP score of ~312 (terrible)
 
 ## JSON Output
 
-The tool outputs a JSON report with method-level CRAP scores, statistics, severity bands, and a namespace hierarchy. See the [specification](https://github.com/7f/crap4dotnet) for the full schema.
+The tool outputs a JSON report with method-level CRAP scores, statistics, severity bands, and a namespace hierarchy. See the [specification](https://github.com/7Factor/crap4dotnet) for the full schema.


### PR DESCRIPTION
## Summary
- Add tag-triggered GitHub Actions workflow (`.github/workflows/publish.yml`) that builds, tests, and publishes to nuget.org on `v*` tags
- Add `RepositoryUrl`, `RepositoryType`, and `PackageProjectUrl` to CLI `.csproj` for complete NuGet package metadata

## Manual steps required after merge
1. Add a `NUGET_API_KEY` secret to the repo (Settings → Secrets → Actions), or configure Trusted Publishing on nuget.org for this repo/workflow
2. Tag a release: `git tag v0.1.0 && git push origin v0.1.0`

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet pack` — produces `.nupkg` with correct metadata
- [x] Inspected `.nuspec` — `projectUrl`, `repository` fields present
- [ ] CI passes on PR
- [ ] After merge: tag `v0.1.0`, verify publish workflow runs

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)